### PR TITLE
Fix tag-major workflow

### DIFF
--- a/.github/workflows/tag-major.yml
+++ b/.github/workflows/tag-major.yml
@@ -3,13 +3,11 @@ on:
   push: { tags: "v*.*.*" }
   workflow_dispatch:
   workflow_call:
-
-permissions: read-all
+permissions: { contents: write }
 
 jobs:
   major:
     if: github.ref_type == 'tag'
-    permissions: { contents: write }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Github's workflow permissions are not as documented.

They say the job permissions override the workflow permisions. And yet, the workflow permissions (before being overridden) ACTUALLY MATTER. Because calling workflows must match the called workflow top-level permissions. Even if all those permissions will be overridden by the jobs. 😡