### PR TITLE
Adds homebrew tap bumps to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   workflow_call:
     inputs:
-      hombrew:
+      homebrew:
         description: 'Boolean to opt-out of releasing to homebrew.'
         default: true
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,15 @@
 name: Release
-on: workflow_call
-permissions: { contents: write }
+on:
+  workflow_call:
+    inputs:
+      hombrew:
+        description: 'Boolean to opt-out of releasing to homebrew.'
+        default: true
+        required: false
+        type: boolean
+
+permissions:
+  contents: write
 
 jobs:
   github:
@@ -11,3 +20,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           tag: ${{ github.ref_name }}
+
+  homebrew:
+    if: inputs.homebrew && !contains(github.ref, '-') # skip prereleases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          homebrew-tap: ${{ contains(fromJSON('["nodenv","node-build"]'),
+            github.event.repository.name)
+            && 'Homebrew/homebrew-core' || 'nodenv/nodenv' }}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           homebrew-tap: ${{ contains(fromJSON('["nodenv","node-build"]'),
             github.event.repository.name)
-            && 'Homebrew/homebrew-core' || 'nodenv/nodenv' }}
+            && 'Homebrew/homebrew-core' || 'nodenv/homebrew-nodenv' }}
         env:
           COMMITTER_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
Defaults to true, but opt-out boolean exists.
The formula name is derived by the action as the repo name.
The tap name is core for nodenv and node-build;
'nodenv/nodenv' otherwise.

Pre-releases are excluded from homebrew releases automatically.
