### PR TITLE
Pin templates to a version

### DIFF
--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -5,4 +5,4 @@ on:
 jobs:
   github:
     permissions: { contents: write }
-    uses: nodenv/.github/.github/workflows/release.yml@main
+    uses: nodenv/.github/.github/workflows/release.yml@v4

--- a/workflow-templates/sync-default-branch.yml
+++ b/workflow-templates/sync-default-branch.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   sync:
     permissions: { contents: write }
-    uses: nodenv/.github/.github/workflows/sync-default-branch.yml@main
+    uses: nodenv/.github/.github/workflows/sync-default-branch.yml@v4

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,9 +1,9 @@
 name: Test
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
-    uses: nodenv/.github/.github/workflows/test.yml@main
+    uses: nodenv/.github/.github/workflows/test.yml@v4
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
These will be out of date, but presumably dependabot will keep them bumped after they're "installed" in each repo.