### PR TITLE
Revert "pushing lightweight tags instead of branches as vN"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: git push -f origin "HEAD:${GITHUB_REF%%.*}"
+      - run: git push -f origin "HEAD:refs/heads/${GITHUB_REF_NAME%%.*}"
 
   npm:
     permissions: {id-token: write}

--- a/.github/workflows/tag-major.yml
+++ b/.github/workflows/tag-major.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: git push -f origin "HEAD:${GITHUB_REF%%.*}"
+      - run: git push -f origin "HEAD:refs/heads/${GITHUB_REF_NAME%%.*}"


### PR DESCRIPTION
Reverts nodenv/.github#23

Reverting: Switch to pushing lightweight tags instead of branches as vN