### PR TITLE
Pin dependencies to sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   github:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - run: |
         # shellcheck disable=SC2086
         gh release create ${tag/*-*/"$tag" --prerelease} --generate-notes
@@ -31,7 +31,7 @@ jobs:
     if: inputs.homebrew && !contains(github.ref, '-') # skip prereleases
     runs-on: ubuntu-latest
     steps:
-    - uses: mislav/bump-homebrew-formula-action@v3
+    - uses: mislav/bump-homebrew-formula-action@b3327118b2153c82da63fd9cbf58942146ee99f0 # v3.1
       with:
         homebrew-tap: ${{ contains(fromJSON('["nodenv","node-build"]'),
           github.event.repository.name)
@@ -43,15 +43,15 @@ jobs:
     if: ${{ !contains(github.ref, '-') }} # skip prereleases
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - run: git push -f origin "HEAD:refs/heads/${GITHUB_REF_NAME%%.*}"
 
   npm:
     permissions: {id-token: write}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with: # FIXME https://github.com/actions/setup-node/pull/129
         scope: ${{ inputs.npm_scope }}
         registry-url: https://registry.npmjs.org

--- a/.github/workflows/sync-default-branch.yml
+++ b/.github/workflows/sync-default-branch.yml
@@ -7,5 +7,5 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - run: git push --force origin HEAD:refs/heads/master

--- a/.github/workflows/tag-major.yml
+++ b/.github/workflows/tag-major.yml
@@ -10,5 +10,5 @@ jobs:
     if: github.ref_type == 'tag' && !contains(github.ref, '-') # skip prereleases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - run: git push -f origin "HEAD:refs/heads/${GITHUB_REF_NAME%%.*}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy: {matrix: {os: [ubuntu, macOS]}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - run: npm cit
 
   super-linter:
@@ -27,9 +27,9 @@ jobs:
     permissions: {contents: read, packages: read, statuses: write}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with: {fetch-depth: 0}
-    - uses: super-linter/super-linter/slim@v6
+    - uses: super-linter/super-linter/slim@5b638caee6ba65e25e07143887b669a1233847a0 # v6.5.1
       env:
         GITHUB_TOKEN: ${{ github.token }}
         BASH_EXEC_IGNORE_LIBRARIES: true # superlinter bug
@@ -39,16 +39,16 @@ jobs:
     permissions: {id-token: write, security-events: write}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: ossf/scorecard-action@v2.3.3
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.3
       with:
         results_file: ossf-scorecard-results.sarif
         results_format: sarif
         publish_results: true
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: ossf-scorecard-results.sarif
         path: ossf-scorecard-results.sarif
-    - uses: github/codeql-action/upload-sarif@v3
+    - uses: github/codeql-action/upload-sarif@f079b8493333aace61c81488f8bd40919487bd9f # v3.25.7
       with:
         sarif_file: ossf-scorecard-results.sarif


### PR DESCRIPTION
Dependabot will still bump them and preserve the version comment https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/

Which is 80% of the reason to not use shas (lack of clarity as to which version it is).

Now if only GHA would stop printing the whole sha in the run log as the action name :(