### PR TITLE
Separate reusable workflow from repo's own test workflow.

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,0 +1,18 @@
+name: Test
+on:
+  pull_request:
+  push: {branches: main}
+  schedule: [{cron: '0 0 10 * *'}] # monthly https://crontab.guru/#0_0_10_*_*
+  workflow_dispatch:
+permissions: {}
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    with: {npm: false}
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+      security-events: write
+      statuses: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,14 @@
 name: Test
 on:
-  pull_request:
-  push: {branches: main}
-  schedule: [{cron: '0 0 10 * *'}] # monthly https://crontab.guru/#0_0_10_*_*
-  workflow_dispatch:
   workflow_call:
     inputs:
+      npm:
+        description: 'Run npm-cit job.'
+        default: true
+        required: false
+        type: boolean
       superlinter:
-        description: 'Boolean to opt-out of super-linter.'
+        description: 'Run super-linter job.'
         default: true
         required: false
         type: boolean
@@ -15,7 +16,7 @@ permissions: {contents: read}
 
 jobs:
   npm-cit:
-    if: github.event_name == 'workflow_call' # skip internal test runs
+    if: inputs.npm
     runs-on: ${{ matrix.os }}-latest
     strategy: {matrix: {os: [ubuntu, macOS]}}
     steps:
@@ -23,7 +24,7 @@ jobs:
     - run: npm cit
 
   super-linter:
-    if: inputs.superlinter || github.event_name != 'workflow_call'
+    if: inputs.superlinter
     permissions: {contents: read, packages: read, statuses: write}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This keeps the "combined" workflow from being too confusing (especially because we the npm job doesn't apply to this repo). This gives the added benefit of actually exercising the `workflow_call` event of the reusable workflow.