### PR TITLE
OSSF Scorecard robustly selects default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         BASH_EXEC_IGNORE_LIBRARIES: true # superlinter bug
 
   ossf-scorecard:
-    if: github.ref_name == 'main'
+    if: github.ref_name == github.event.repository.default_branch
     permissions: {id-token: write, security-events: write}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Don't hardcode the branch name; compare with the default configuration.