### PR TITLE
Community health links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ while also running most of those same tests within this repository itself.
 
 ## Releasing
 
-1. [Draft a new release](https://github.com/nodenv/.github/releases/new)
+1. [Draft a new release](../../releases/new)
 2. Decide on next tag based on SemVer
 3. Generate release notes (button)
 4. Publish

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,6 @@ though it is instead recommended to pin to a specific git-sha and use [Dependabo
 
 Use GitHub's [built-in reporting mechanism][gh-security].
 
-[latest-release]: ../../../releases/latest
+[latest-release]: ../../releases/latest
 [dependabot]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions
-[gh-security]: ../../../security/advisories/new
+[gh-security]: ../../security/advisories/new


### PR DESCRIPTION
docs: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

Links must be two levels deep for relative paths to work. Which means these files must be in the root for the links to work _in_ this repo as well as in the other nodenv repos.