### PR TITLE
Lint all nodenv repos

### DIFF
--- a/.github/workflows/.github_test.yml
+++ b/.github/workflows/.github_test.yml
@@ -24,25 +24,25 @@ jobs:
       fail-fast: false
       matrix:
         repo:
-          - actions
-          - homebrew-nodenv
-          - jetbrains-npm
+          # - actions
+          # - homebrew-nodenv
+          # - jetbrains-npm
           - node-build
-          - node-build-prerelease
-          - node-build-update-defs
+          # - node-build-prerelease
+          # - node-build-update-defs
           - nodenv
           - nodenv-aliases
-          - nodenv-default-packages
-          - nodenv-each
-          - nodenv-env
-          - nodenv-installer
-          - nodenv-man
-          - nodenv-npm-migrate
-          - nodenv-nvmrc
+          # - nodenv-default-packages
+          # - nodenv-each
+          # - nodenv-env
+          # - nodenv-installer
+          # - nodenv-man
+          # - nodenv-npm-migrate
+          # - nodenv-nvmrc
           - nodenv-package-json-engine
-          - nodenv-package-rehash
+          # - nodenv-package-rehash
           - nodenv-update
-          - nodenv-vars
+          # - nodenv-vars
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with: { egress-policy: audit }

--- a/.github/workflows/.github_test.yml
+++ b/.github/workflows/.github_test.yml
@@ -27,11 +27,11 @@ jobs:
           - actions
           - homebrew-nodenv
           - jetbrains-npm
-          # - node-build
+          - node-build
           - node-build-prerelease
           - node-build-update-defs
-          # - nodenv
-          # - nodenv-aliases
+          - nodenv
+          - nodenv-aliases
           - nodenv-default-packages
           - nodenv-each
           - nodenv-env
@@ -39,9 +39,9 @@ jobs:
           - nodenv-man
           - nodenv-npm-migrate
           - nodenv-nvmrc
-          # - nodenv-package-json-engine
+          - nodenv-package-json-engine
           - nodenv-package-rehash
-          # - nodenv-update
+          - nodenv-update
           - nodenv-vars
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
Disables all the green repos and enables the red ones. So any green jobs should update the corresponding repo.