### PR TITLE
The superlinter job clones its own repo into the runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,12 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { fetch-depth: 0, persist-credentials: false }
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .github/workflows/${{ job.workflow_repository }}
+          persist-credentials: false
       - uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This allows the superlinter job to reference files that exist in the
reusable workflow's repo (thus sharing configuration for the linter
tools themselves).
