### PR TITLE
Ship custom codespell config

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,4 +1,4 @@
 # https://github.com/super-linter/super-linter/blob/main/TEMPLATES/.codespellrc
 [codespell]
 check-hidden =
-skip = */package-lock.json,*/go.mod,*/go.sum,*.log,.git
+skip = */package-lock.json,*/go.mod,*/go.sum,*.log,.git,share/man

--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,4 @@
+# https://github.com/super-linter/super-linter/blob/main/TEMPLATES/.codespellrc
+[codespell]
+check-hidden =
+skip = */package-lock.json,*/go.mod,*/go.sum,*.log,.git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           VALIDATE_GIT_COMMITLINT: false # commitlint is bad
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_JSCPD: false # too prone to false-positives
-          VALIDATE_SPELL_CODESPELL: false # TODO
+          SPELL_CODESPELL_CONFIG_FILE: .github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
 
   dependency-review:
     if: startsWith('pull_request', github.event_name)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ job.workflow_sha }}
           path: .github/workflows/${{ job.workflow_repository }}
           persist-credentials: false
-      - run: ls -al .github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
+      - run: pwd && ls -al .github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
       - uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ job.workflow_sha }}
           path: .github/workflows/${{ job.workflow_repository }}
           persist-credentials: false
-      - run: pwd && ls -al .github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
+      - run: pwd && ls -al ${{ github.workspace }}/.github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
       - uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -56,7 +56,7 @@ jobs:
           VALIDATE_GIT_COMMITLINT: false # commitlint is bad
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_JSCPD: false # too prone to false-positives
-          SPELL_CODESPELL_CONFIG_FILE: .github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
+          SPELL_CODESPELL_CONFIG_FILE: ${{ github.workspace }}/.github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
 
   dependency-review:
     if: startsWith('pull_request', github.event_name)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
           ref: ${{ job.workflow_sha }}
           path: .github/workflows/${{ job.workflow_repository }}
           persist-credentials: false
+      - run: ls -al .github/workflows/${{ job.workflow_repository }}/.github/linters/.codespellrc
       - uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The superlinter job now does a checkout of this very repository, thus allowing the reusable workflow to share configuration that depends on files. (Without needing to duplicate the configuration into every calling repo.)

Presently, the only customization is to ignore generated share/man pages, thanks to codespell being unable to cleanly inspect manpages.