### PR TITLE
superlinter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,15 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { fetch-depth: 0, persist-credentials: false }
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: ${{ job.workflow_repository }}
-          ref: ${{ job.workflow_sha }}
-          path: .github/workflows/${{ job.workflow_repository }}
-          persist-credentials: false
+      # eventually check out .github repo itself to support sharing of config files.
+      # not necessary right now since codespell is borked.
+      # also, superlinter is behind and doesn't recognize job.workflow_* vars used below
+      # - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      #   with:
+      #     repository: ${{ job.workflow_repository }}
+      #     ref: ${{ job.workflow_sha }}
+      #     path: .github/workflows/${{ job.workflow_repository }}
+      #     persist-credentials: false
       - uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           VALIDATE_BIOME_LINT: false # conflicts with prettier
           VALIDATE_GIT_COMMITLINT: false # commitlint is bad
           VALIDATE_JSCPD: false # too prone to false-positives
-          VALIDATE_SPELL_CODESPELL: false # TODO
+          VALIDATE_SPELL_CODESPELL: false # too many false-positives
 
   dependency-review:
     if: startsWith('pull_request', github.event_name)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
           VALIDATE_BIOME_FORMAT: false # conflicts with prettier
           VALIDATE_BIOME_LINT: false # conflicts with prettier
           VALIDATE_GIT_COMMITLINT: false # commitlint is bad
-          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_JSCPD: false # too prone to false-positives
           VALIDATE_SPELL_CODESPELL: false # TODO
 


### PR DESCRIPTION
- **restore zizmor**
  We may as well just pin our own .github workflows. It sucks. Blame
  zizmor. But I'd rather keep zizmor enabled, and pinning the workflows is
  not terrible with dependabot handling bumps. (And we don't cut releases
  that often anyway.)
  

- **keep codespell disabled**
  Codespell can't respect custom codespellrc because of how superlinter
  passes in explicit file arguments. Which means we can't override the
  skip list.
  
  Too many false positives to be valuable.
  